### PR TITLE
added comma separated to the math words

### DIFF
--- a/mathwords.txt
+++ b/mathwords.txt
@@ -1,712 +1,713 @@
 Euler's formula
-Feigenbaum constants
-Butterfly effect
-Hilbert's problems
-Zero of a function
-Operations research
-Bessel function
-Lebesgue integration
-Binary search algorithm
-Inverse hyperbolic functions
-Vector-valued function
-Rectangle
-Mathematical logic
-Factorial
-Differential form
-Root of unity
-Algebraic expression
-Singularity
-Fraction
-Stochastic process
-Function composition
-Godel's incompleteness theorems
-Skewness
-Set theory
-Mathematics
-Computability theory
-Catalan number
-Category theory
-Topological space
-Logarithm
-Cantor's theorem
-Survey methodology
-Cube
-Indeterminate form
-Cycle
-Commutative algebra
-Chi-squared test
-Propositional calculus
- injection and surjection
-Octahedron
-Constructible number
-Bayesian statistics
-Sorting algorithm
-Lambert W function
-Binary search tree
-Total derivative
-Volume
-Union
-Approximation theory
-Harmonic analysis
-Coordinate system
-Field (mathematics)
-Rectangular function
-
-Statistical hypothesis testing
-Trapezoid
-Arithmetic mean
-Variance
-Series expansion
-Weierstrass function
-Constant
-Axiom schema of replacement
-120-cell
--1
-Halting problem
-Elliptic curve
-P
-Riemann sum
-Complex analysis
-Wiener process
-Contour integration
-Binomial distribution
-Mode
-Poisson's equation
-Polynomial
-Manifold
-Limits of integration
-Theorem
-Computable function
-Cauchy's integral formula
-Algorithm
-Quadratic equation
-Correlation and dependence
-Catenary
-Perfect number
-Natural logarithm
-Group representation
-Cauchy-Schwarz inequality
-Random variable
-Coprime integers
-Stack
-Antiderivative
-Euler's identity
-Linear function
-Trigonometry
-Cardinal number
-Hilbert space
-Mathematical problem
-Monty Hall problem
-Differentiation rules
-Function of several real variables
-Hamming code
-Riemann sphere
-Algebraic geometry
-Multiplication sign
-Moment
-e
-Floor and ceiling functions
-Step function
-Linear programming
-Fixed point
-Taylor's theorem
-Extreme value theorem
-Numerical integration
-Constant of integration
-Diophantine equation
-Linear regression
-Banach space
-Quantum cohomology
-Related rates
-Symmetry
-Ordinal number
-Data structure
-Regular polygon
-Differentiable function
-Pyramid
-Cantor set
-Laplace operator
-RSA
-Kelvin–Stokes theorem
-Probability density function
-Poincare conjecture
-Maximum a posteriori estimation
-Group
-Boundary value problem
-Obelus
-Polyhedron
-Exponential distribution
-Locus
-Monte Carlo method
-Reed–Solomon error correction
-Cube root
-Sphere
-Dynamical system
-Laplace transform
-Abstract machine
-Poisson process
-Gradient theorem
-Graph
-Elliptic operator
-Convergent series
-Equation
-Sample mean and covariance
-Binomial series
-Fermat's Last Theorem
-Series
-Convex set
-Arithmetic
-Partially ordered set
-Koch snowflake
-Simplex algorithm
-Three-body problem
-Abstract data type
-Calculus
-Ramsey theory
-Linear differential equation
-Student's t-test
-Harmonic function
-Applied mathematics
-Data visualization
-Numeral system
-Square root of 2
-Negation
-Geometric mean
-NP-hardness
-Limit
-Graph
-Power rule
-Mathematician
-Isomorphism
-Variable
-NP
-Differential calculus
-Quadratic formula
-Extended real number line
-Quadratic reciprocity
-Tetrahedron
-Complex logarithm
-Entire function
-Zero-sum game
-Modularity theorem
-Tensor
-Surface integral
-Function
-Game theory
-Semiprime
-A/B testing
-Linearization
-Internal and external angles
-Prime number
-Search algorithm
-Ellipse
-Function of a real variable
-Logistic regression
-Depth-first search
-Imaginary unit
-Axiom schema of specification
-p-value
-Parity
-Error function
-Tree
-Pseudoprime
-Residue theorem
-Riemann hypothesis
-Binary logarithm
-B-tree
-Algebraic number field
-Combination
-5-cell
-Fundamental group
-Common logarithm
-Bijection
-Cross product
-Hyperbolic function
-Power series solution of differential equations
-Icosahedron
-Scaling
-Cartesian coordinate system
-Zorn's lemma
-Fourier transform
-Reflection
-Quadratic function
-Lattice
-Rotations in 4-dimensional Euclidean space
-Composite number
-Height
-Square root
-Fourier series
-Limit of a function
-Range
-Lyapunov exponent
-Dynamic programming
-Error detection and correction
-Bayes' theorem
-Infinity
-Ring theory
-Metric space
-Euclidean algorithm
-5
-Residue
-Infinitesimal
-Sheaf
-Parametric equation
-Recreational mathematics
-Hash table
-Axiom of power set
-Tesseract
-Finite field
-Analytic function
-Associative property
-Solid angle
-Observational study
-Linked list
-Linear algebra
-Nonlinear system
-Euclidean geometry
-Expected value
-Dirac delta function
-Fermat's Little Theorem
-Boolean algebra
-Inner product space
-Kronecker delta
-Homology
-Church-Turing thesis
-Cardioid
-Turing machine
-Linear equation
-Polygon
-2
-Context-free grammar
-Field line
-Chomsky hierarchy
-Decimal
-Percentage
-Liouville's theorem
-Finite element method
-Cone
-Cumulative distribution function
-Abstract algebra
-Surjective function
-Riemann zeta function
-Long division
-Exterior algebra
-Commutative property
-Transcendental number
-Statistics
-Dodecahedron
-Algebra
-Sierpinski triangle
-Positional notation
-Regular polyhedron
-Discrete mathematics
-Gradient
-Kurtosis
-Algebraic number
-Limit cycle
-10
-Trigonometric functions
-Standard deviation
-Multivariable calculus
-Tensor calculus
-Pure mathematics
-Probability space
-Asymptote
-Real line
-Four color theorem
-Normal number
-Design of experiments
-Right angle
-Three-dimensional space
-Equation solving
-Mathematical optimization
-Meta-analysis
-600-cell
-Stirling's approximation
-Triangle
-Order of operations
-Rotation
-Dirichlet series
-Modular arithmetic
-Abelian group
-Bifurcation theory
-Axiom of choice
-Decimal separator
-Algebraic equation
-3
-Fractal
-Holomorphic function
-Sine
-Equivalence relation
-Bijection
-Sign
-Square
-Dirichlet problem
-Negative number
-Differential geometry
-Heap
-Squeeze theorem
-Computational complexity theory
-Markov chain
-Statistical significance
-Mean value theorem
-Elementary function
-Tessellation
-Algebraic topology
-Axiom of infinity
-Constant function
-Banach–Tarski paradox
-Differential
-Discrete uniform distribution
-Bounded function
-Axiom
-Curvature
-Dot product
-Angle
-Inverse trigonometric functions
-Twin prime
-Prism
-9
-Mathematical analysis
-Absolute convergence
-Differential equation
-Elementary algebra
-Topology
-Algebraic number theory
-Analytic geometry
-Inequality
-Data compression
-Russell's paradox
-Pi
-Euler–Mascheroni constant
-Naive set theory
-Conformal map
-1
-Theoretical computer science
-Bayesian inference
-Regular dodecahedron
-Representation theory
-Real number
-Field extension
-Open set
-Product rule
-Regression
-8
-Euclidean vector
-Frequentist statistics
-Mersenne prime
-Dynamic simulation
-Change of variables
-Probability mass function
-Chaos theory
-Well-ordering theorem
-Determinant
-Zeros and poles
-Gamma function
-Zermelo–Fraenkel set theory
-Law of sines
-Even and odd functions
-Length
-Cardinality
-Isosceles triangle
-Non-Euclidean geometry
-Flow
-Power series
-Multiple integral
-Fundamental theorem of calculus
-Measure
-Formal language
-String searching algorithm
-Octagon
-Information theory
-Fundamental theorem of algebra
-Moduli space
-Integration by substitution
-Complex number
-Distributive property
-Equilateral triangle
-Square
-Vector space
-Axiom of pairing
-Probability
-Combinatorics
-Galois theory
-Euclid's theorem
-Symmetry in mathematics
-Separation of variables
-Differential operator
-Area
-Generating function
-Calculus of variations
-Exponential growth
-Axiom of regularity
-Chain rule
-Stability theory
-Prisoner's dilemma
-Algebraic function
-Moment-generating function
-Laplace's equation
-Jensen's inequality
-Euler method
-Graph theory
-Solenoidal vector field
-Linear map
-Rhombus
-Real-valued function
-Cauchy principal value
-Geometric series
-Number theory
-Roman numerals
-Imaginary number
-Divergence
-Least squares
-Knot theory
-Helmholtz decomposition
-Harmonic conjugate
-Green's theorem
-Numerical analysis
-Improper integral
-16-cell
-Gaussian elimination
-Boolean satisfiability problem
-Affine space
-Piecewise
-6
-Breadth-first search
-Compact space
-4
-Partial differential equation
-Normal distribution
-Fermat number
-Complex plane
-Line integral
-Scientific notation
-Partial derivative
-Modular group
-Galois group
-Decagon
-Viterbi algorithm
-0
-Critical point
-Minkowski's theorem
-Jacobian matrix and determinant
-Array
-Group theory
-Sampling
-Covariance
-Plus and minus signs
-Hyperbola
-Riemann surface
-Division
-Initial condition
-Set
-Maxima and minima
-Newton's method
-Fourier analysis
-Circle
-Pythagorean theorem
-Differentiation of trigonometric functions
-Division by zero
-Surface area
-Rational number
-Irrational number
-Numerical digit
-Periodic function
-Integrating factor
-Lambda calculus
-Magic square
-Classification of finite simple groups
-Spherical coordinate system
-Euclidean space
-Conserved quantity
-Pentagon
-Venn diagram
-Radius of convergence
-Probability theory
-7
-Queue
-Second derivative
-Natural number
-Type I and type II errors
-Line
-Statistical population
-Stationary point
-Addition
-Probability distribution
-Geometry
-Control theory
-Inverse function
-Asymptotic analysis
-Parallelogram
-Phase space
-Subset
-Integration by parts
-Polar coordinate system
-Four-dimensional space
-Integer
-Riemannian geometry
-Vector calculus
-Number
-Central limit theorem
-Harmonic mean
-Computable number
-Heaviside step function
-Divergence theorem
-Exponentiation
-Analysis of algorithms
-Commutative ring
-Formula
-Monomial
-Credible interval
-Attractor
-P versus NP problem
-Exponential function
-Derivative
-Poisson distribution
-One-factor-at-a-time method
-Aliquot sum
-Parabola
-Curl
-Limit of a sequence
-Brachistochrone curve
-Complex-valued function
-Conjecture
-nth root
-Elliptic function
-Gaussian function
-Multiplication
-Rational function
-(e d)-definition of limit
-Numerical methods for ordinary differential equations
-Directional derivative
-Fibonacci number
-Edge of chaos
-Median
-Plane
-Matrix
-Saddle point
-Binary number
-Standard error
-Intersection
-Chinese remainder theorem
-Nash equilibrium
-Prior probability
-Cylinder
-Shortest path problem
-Permutation
-Golden ratio
-Identity function
-Taylor series
-Distance
-Dijkstra's algorithm
-Vector field
-Cycloid
-Systolic geometry
-Mobius function
-Module
-Trinomial
-Homogeneous differential equation
-Multiplicative inverse
-Absolute value
-Divergent series
-Linear dynamical system
-24-cell
-Karnaugh map
-Ordinary differential equation
-Eigenvalues and eigenvectors
-Axiom of extensionality
-Maximum likelihood estimation
-Linear approximation
-Time complexity
-Integral
-Regular icosahedron
-Convergence tests
-Empty set
-Lagrange multiplier
-Multipole expansion
-L'Hopital's rule
-Confidence interval
-Potential theory
-Unit circle
-Stokes' theorem
-Peano axioms
-Dynamical systems theory
-Diffie–Hellman key exchange
-Sequence
-Dihedral angle
-Percent sign
-Branch point
-Riemann integral
-Dimension
-Del
-Nonlinear programming
-Big O notation
-Binomial
-Hexagon
-Real analysis
-Tree
-Cauchy–Riemann equations
-Axiom of union
-Sign function
-Quicksort
-Algebraic variety
-Platonic solid
-Ring
-Functional analysis
-Homological algebra
-Julia set
-General topology
-Picard theorem
-Right triangle
-Holder's inequality
-Continued fraction
-Conic section
-Posterior probability
-Multibody system
-Mean
-Arabic numerals
-Harmonic series
-Complement
-Lemniscate
-Von Neumann universe
-Mathematical proof
-Two-dimensional space
-Law of large numbers
-Mandelbrot set
-Graph coloring
-Fundamental theorem of arithmetic
-Domain of a function
-Conservative vector field
-Magnitude
-Chi-squared distribution
-Expectation–maximization algorithm
-Fast Fourier transform
-Homotopy
-Laurent series
-Iterated integral
-Cylindrical coordinate system
-Class field theory
-Law of cosines
-Volume integral
-Polynomial ring
-Inflection point
-Bell number
-Randomized controlled trial
-Continuous function
-Shape
-Analytic number theory
-Convolution theorem
-Mathematical induction
-Theory of computation
-Numerical partial differential equations
-Quadrilateral
-Prime number theorem
-Intermediate value theorem
-Point
-Continuous uniform distribution
-Coding theory
-Subtraction
-Euler characteristic
-Implicit function
-Graph of a function
-Injective function
+,Feigenbaum constants
+,Butterfly effect
+,Hilbert's problems
+,Zero of a function
+,Operations research
+,Bessel function
+,Lebesgue integration
+,Binary search algorithm
+,Inverse hyperbolic functions
+,Vector-valued function
+,Rectangle
+,Mathematical logic
+,Factorial
+,Differential form
+,Root of unity
+,Algebraic expression
+,Singularity
+,Fraction
+,Stochastic process
+,Function composition
+,Godel's incompleteness theorems
+,Skewness
+,Set theory
+,Mathematics
+,Computability theory
+,Catalan number
+,Category theory
+,Topological space
+,Logarithm
+,Cantor's theorem
+,Survey methodology
+,Cube
+,Indeterminate form
+,Cycle
+,Commutative algebra
+,Chi-squared test
+,Propositional calculus
+, injection and surjection
+,Octahedron
+,Constructible number
+,Bayesian statistics
+,Sorting algorithm
+,Lambert W function
+,Binary search tree
+,Total derivative
+,Volume
+,Union
+,Approximation theory
+,Harmonic analysis
+,Coordinate system
+,Field (mathematics)
+,Rectangular function
+,
+,Statistical hypothesis testing
+,Trapezoid
+,Arithmetic mean
+,Variance
+,Series expansion
+,Weierstrass function
+,Constant
+,Axiom schema of replacement
+,120-cell
+,-1
+,Halting problem
+,Elliptic curve
+,P
+,Riemann sum
+,Complex analysis
+,Wiener process
+,Contour integration
+,Binomial distribution
+,Mode
+,Poisson's equation
+,Polynomial
+,Manifold
+,Limits of integration
+,Theorem
+,Computable function
+,Cauchy's integral formula
+,Algorithm
+,Quadratic equation
+,Correlation and dependence
+,Catenary
+,Perfect number
+,Natural logarithm
+,Group representation
+,Cauchy-Schwarz inequality
+,Random variable
+,Coprime integers
+,Stack
+,Antiderivative
+,Euler's identity
+,Linear function
+,Trigonometry
+,Cardinal number
+,Hilbert space
+,Mathematical problem
+,Monty Hall problem
+,Differentiation rules
+,Function of several real variables
+,Hamming code
+,Riemann sphere
+,Algebraic geometry
+,Multiplication sign
+,Moment
+,e
+,Floor and ceiling functions
+,Step function
+,Linear programming
+,Fixed point
+,Taylor's theorem
+,Extreme value theorem
+,Numerical integration
+,Constant of integration
+,Diophantine equation
+,Linear regression
+,Banach space
+,Quantum cohomology
+,Related rates
+,Symmetry
+,Ordinal number
+,Data structure
+,Regular polygon
+,Differentiable function
+,Pyramid
+,Cantor set
+,Laplace operator
+,RSA
+,Kelvin–Stokes theorem
+,Probability density function
+,Poincare conjecture
+,Maximum a posteriori estimation
+,Group
+,Boundary value problem
+,Obelus
+,Polyhedron
+,Exponential distribution
+,Locus
+,Monte Carlo method
+,Reed–Solomon error correction
+,Cube root
+,Sphere
+,Dynamical system
+,Laplace transform
+,Abstract machine
+,Poisson process
+,Gradient theorem
+,Graph
+,Elliptic operator
+,Convergent series
+,Equation
+,Sample mean and covariance
+,Binomial series
+,Fermat's Last Theorem
+,Series
+,Convex set
+,Arithmetic
+,Partially ordered set
+,Koch snowflake
+,Simplex algorithm
+,Three-body problem
+,Abstract data type
+,Calculus
+,Ramsey theory
+,Linear differential equation
+,Student's t-test
+,Harmonic function
+,Applied mathematics
+,Data visualization
+,Numeral system
+,Square root of 2
+,Negation
+,Geometric mean
+,NP-hardness
+,Limit
+,Graph
+,Power rule
+,Mathematician
+,Isomorphism
+,Variable
+,NP
+,Differential calculus
+,Quadratic formula
+,Extended real number line
+,Quadratic reciprocity
+,Tetrahedron
+,Complex logarithm
+,Entire function
+,Zero-sum game
+,Modularity theorem
+,Tensor
+,Surface integral
+,Function
+,Game theory
+,Semiprime
+,A/B testing
+,Linearization
+,Internal and external angles
+,Prime number
+,Search algorithm
+,Ellipse
+,Function of a real variable
+,Logistic regression
+,Depth-first search
+,Imaginary unit
+,Axiom schema of specification
+,p-value
+,Parity
+,Error function
+,Tree
+,Pseudoprime
+,Residue theorem
+,Riemann hypothesis
+,Binary logarithm
+,B-tree
+,Algebraic number field
+,Combination
+,5-cell
+,Fundamental group
+,Common logarithm
+,Bijection
+,Cross product
+,Hyperbolic function
+,Power series solution of differential equations
+,Icosahedron
+,Scaling
+,Cartesian coordinate system
+,Zorn's lemma
+,Fourier transform
+,Reflection
+,Quadratic function
+,Lattice
+,Rotations in 4-dimensional Euclidean space
+,Composite number
+,Height
+,Square root
+,Fourier series
+,Limit of a function
+,Range
+,Lyapunov exponent
+,Dynamic programming
+,Error detection and correction
+,Bayes' theorem
+,Infinity
+,Ring theory
+,Metric space
+,Euclidean algorithm
+,5
+,Residue
+,Infinitesimal
+,Sheaf
+,Parametric equation
+,Recreational mathematics
+,Hash table
+,Axiom of power set
+,Tesseract
+,Finite field
+,Analytic function
+,Associative property
+,Solid angle
+,Observational study
+,Linked list
+,Linear algebra
+,Nonlinear system
+,Euclidean geometry
+,Expected value
+,Dirac delta function
+,Fermat's Little Theorem
+,Boolean algebra
+,Inner product space
+,Kronecker delta
+,Homology
+,Church-Turing thesis
+,Cardioid
+,Turing machine
+,Linear equation
+,Polygon
+,2
+,Context-free grammar
+,Field line
+,Chomsky hierarchy
+,Decimal
+,Percentage
+,Liouville's theorem
+,Finite element method
+,Cone
+,Cumulative distribution function
+,Abstract algebra
+,Surjective function
+,Riemann zeta function
+,Long division
+,Exterior algebra
+,Commutative property
+,Transcendental number
+,Statistics
+,Dodecahedron
+,Algebra
+,Sierpinski triangle
+,Positional notation
+,Regular polyhedron
+,Discrete mathematics
+,Gradient
+,Kurtosis
+,Algebraic number
+,Limit cycle
+,10
+,Trigonometric functions
+,Standard deviation
+,Multivariable calculus
+,Tensor calculus
+,Pure mathematics
+,Probability space
+,Asymptote
+,Real line
+,Four color theorem
+,Normal number
+,Design of experiments
+,Right angle
+,Three-dimensional space
+,Equation solving
+,Mathematical optimization
+,Meta-analysis
+,600-cell
+,Stirling's approximation
+,Triangle
+,Order of operations
+,Rotation
+,Dirichlet series
+,Modular arithmetic
+,Abelian group
+,Bifurcation theory
+,Axiom of choice
+,Decimal separator
+,Algebraic equation
+,3
+,Fractal
+,Holomorphic function
+,Sine
+,Equivalence relation
+,Bijection
+,Sign
+,Square
+,Dirichlet problem
+,Negative number
+,Differential geometry
+,Heap
+,Squeeze theorem
+,Computational complexity theory
+,Markov chain
+,Statistical significance
+,Mean value theorem
+,Elementary function
+,Tessellation
+,Algebraic topology
+,Axiom of infinity
+,Constant function
+,Banach–Tarski paradox
+,Differential
+,Discrete uniform distribution
+,Bounded function
+,Axiom
+,Curvature
+,Dot product
+,Angle
+,Inverse trigonometric functions
+,Twin prime
+,Prism
+,9
+,Mathematical analysis
+,Absolute convergence
+,Differential equation
+,Elementary algebra
+,Topology
+,Algebraic number theory
+,Analytic geometry
+,Inequality
+,Data compression
+,Russell's paradox
+,Pi
+,Euler–Mascheroni constant
+,Naive set theory
+,Conformal map
+,1
+,Theoretical computer science
+,Bayesian inference
+,Regular dodecahedron
+,Representation theory
+,Real number
+,Field extension
+,Open set
+,Product rule
+,Regression
+,8
+,Euclidean vector
+,Frequentist statistics
+,Mersenne prime
+,Dynamic simulation
+,Change of variables
+,Probability mass function
+,Chaos theory
+,Well-ordering theorem
+,Determinant
+,Zeros and poles
+,Gamma function
+,Zermelo–Fraenkel set theory
+,Law of sines
+,Even and odd functions
+,Length
+,Cardinality
+,Isosceles triangle
+,Non-Euclidean geometry
+,Flow
+,Power series
+,Multiple integral
+,Fundamental theorem of calculus
+,Measure
+,Formal language
+,String searching algorithm
+,Octagon
+,Information theory
+,Fundamental theorem of algebra
+,Moduli space
+,Integration by substitution
+,Complex number
+,Distributive property
+,Equilateral triangle
+,Square
+,Vector space
+,Axiom of pairing
+,Probability
+,Combinatorics
+,Galois theory
+,Euclid's theorem
+,Symmetry in mathematics
+,Separation of variables
+,Differential operator
+,Area
+,Generating function
+,Calculus of variations
+,Exponential growth
+,Axiom of regularity
+,Chain rule
+,Stability theory
+,Prisoner's dilemma
+,Algebraic function
+,Moment-generating function
+,Laplace's equation
+,Jensen's inequality
+,Euler method
+,Graph theory
+,Solenoidal vector field
+,Linear map
+,Rhombus
+,Real-valued function
+,Cauchy principal value
+,Geometric series
+,Number theory
+,Roman numerals
+,Imaginary number
+,Divergence
+,Least squares
+,Knot theory
+,Helmholtz decomposition
+,Harmonic conjugate
+,Green's theorem
+,Numerical analysis
+,Improper integral
+,16-cell
+,Gaussian elimination
+,Boolean satisfiability problem
+,Affine space
+,Piecewise
+,6
+,Breadth-first search
+,Compact space
+,4
+,Partial differential equation
+,Normal distribution
+,Fermat number
+,Complex plane
+,Line integral
+,Scientific notation
+,Partial derivative
+,Modular group
+,Galois group
+,Decagon
+,Viterbi algorithm
+,0
+,Critical point
+,Minkowski's theorem
+,Jacobian matrix and determinant
+,Array
+,Group theory
+,Sampling
+,Covariance
+,Plus and minus signs
+,Hyperbola
+,Riemann surface
+,Division
+,Initial condition
+,Set
+,Maxima and minima
+,Newton's method
+,Fourier analysis
+,Circle
+,Pythagorean theorem
+,Differentiation of trigonometric functions
+,Division by zero
+,Surface area
+,Rational number
+,Irrational number
+,Numerical digit
+,Periodic function
+,Integrating factor
+,Lambda calculus
+,Magic square
+,Classification of finite simple groups
+,Spherical coordinate system
+,Euclidean space
+,Conserved quantity
+,Pentagon
+,Venn diagram
+,Radius of convergence
+,Probability theory
+,7
+,Queue
+,Second derivative
+,Natural number
+,Type I and type II errors
+,Line
+,Statistical population
+,Stationary point
+,Addition
+,Probability distribution
+,Geometry
+,Control theory
+,Inverse function
+,Asymptotic analysis
+,Parallelogram
+,Phase space
+,Subset
+,Integration by parts
+,Polar coordinate system
+,Four-dimensional space
+,Integer
+,Riemannian geometry
+,Vector calculus
+,Number
+,Central limit theorem
+,Harmonic mean
+,Computable number
+,Heaviside step function
+,Divergence theorem
+,Exponentiation
+,Analysis of algorithms
+,Commutative ring
+,Formula
+,Monomial
+,Credible interval
+,Attractor
+,P versus NP problem
+,Exponential function
+,Derivative
+,Poisson distribution
+,One-factor-at-a-time method
+,Aliquot sum
+,Parabola
+,Curl
+,Limit of a sequence
+,Brachistochrone curve
+,Complex-valued function
+,Conjecture
+,nth root
+,Elliptic function
+,Gaussian function
+,Multiplication
+,Rational function
+,(e d)-definition of limit
+,Numerical methods for ordinary differential equations
+,Directional derivative
+,Fibonacci number
+,Edge of chaos
+,Median
+,Plane
+,Matrix
+,Saddle point
+,Binary number
+,Standard error
+,Intersection
+,Chinese remainder theorem
+,Nash equilibrium
+,Prior probability
+,Cylinder
+,Shortest path problem
+,Permutation
+,Golden ratio
+,Identity function
+,Taylor series
+,Distance
+,Dijkstra's algorithm
+,Vector field
+,Cycloid
+,Systolic geometry
+,Mobius function
+,Module
+,Trinomial
+,Homogeneous differential equation
+,Multiplicative inverse
+,Absolute value
+,Divergent series
+,Linear dynamical system
+,24-cell
+,Karnaugh map
+,Ordinary differential equation
+,Eigenvalues and eigenvectors
+,Axiom of extensionality
+,Maximum likelihood estimation
+,Linear approximation
+,Time complexity
+,Integral
+,Regular icosahedron
+,Convergence tests
+,Empty set
+,Lagrange multiplier
+,Multipole expansion
+,L'Hopital's rule
+,Confidence interval
+,Potential theory
+,Unit circle
+,Stokes' theorem
+,Peano axioms
+,Dynamical systems theory
+,Diffie–Hellman key exchange
+,Sequence
+,Dihedral angle
+,Percent sign
+,Branch point
+,Riemann integral
+,Dimension
+,Del
+,Nonlinear programming
+,Big O notation
+,Binomial
+,Hexagon
+,Real analysis
+,Tree
+,Cauchy–Riemann equations
+,Axiom of union
+,Sign function
+,Quicksort
+,Algebraic variety
+,Platonic solid
+,Ring
+,Functional analysis
+,Homological algebra
+,Julia set
+,General topology
+,Picard theorem
+,Right triangle
+,Holder's inequality
+,Continued fraction
+,Conic section
+,Posterior probability
+,Multibody system
+,Mean
+,Arabic numerals
+,Harmonic series
+,Complement
+,Lemniscate
+,Von Neumann universe
+,Mathematical proof
+,Two-dimensional space
+,Law of large numbers
+,Mandelbrot set
+,Graph coloring
+,Fundamental theorem of arithmetic
+,Domain of a function
+,Conservative vector field
+,Magnitude
+,Chi-squared distribution
+,Expectation–maximization algorithm
+,Fast Fourier transform
+,Homotopy
+,Laurent series
+,Iterated integral
+,Cylindrical coordinate system
+,Class field theory
+,Law of cosines
+,Volume integral
+,Polynomial ring
+,Inflection point
+,Bell number
+,Randomized controlled trial
+,Continuous function
+,Shape
+,Analytic number theory
+,Convolution theorem
+,Mathematical induction
+,Theory of computation
+,Numerical partial differential equations
+,Quadrilateral
+,Prime number theorem
+,Intermediate value theorem
+,Point
+,Continuous uniform distribution
+,Coding theory
+,Subtraction
+,Euler characteristic
+,Implicit function
+,Graph of a function
+,Injective function
+,


### PR DESCRIPTION
It seems like if the words are not comma separated (i.e. enter-separated) then skribbl treats them as one word. So I have added commas in between the lines to allow skribbl to recognise these as separate words. 